### PR TITLE
Update GmbToken model

### DIFF
--- a/GmbToken.js
+++ b/GmbToken.js
@@ -18,5 +18,10 @@ module.exports = {
     location: {
       type: 'string',
     },
+    status: {
+      type: 'string',
+      enum: ['Pending', 'GmbTab', 'GmbBulk'],
+      defaultsTo: 'Pending',
+    },
   },
 };


### PR DESCRIPTION
Added `state` property in order to differentiate between `GmbTokens` handled in `Gmb Tab` and `Gmb Bulk` process, as well as pending tokens.