### PR TITLE
Add Feature DEV-2095 Add addressExtraObject to LegacyClient model

### DIFF
--- a/LegacyClient.js
+++ b/LegacyClient.js
@@ -56,6 +56,9 @@ module.exports = {
       type: 'string',
       columnName: 'suite',
     },
+    addressExtraObject: {
+      type: 'json',
+    },
     hours: {
       type: 'string',
       columnName: 'd14',


### PR DESCRIPTION
Add `addressExtraObject` to LegacyClient model in order to include additional address information based on [DEV-2095](https://adviceinteractive.atlassian.net/browse/DEV-2095).
