### PR TITLE
Feature/plan 261/add products deactivation interval to the products table

### DIFF
--- a/LegacyProduct.js
+++ b/LegacyProduct.js
@@ -1,11 +1,11 @@
 'use strict';
 
 module.exports = {
-	connection: 'mysql',
+  connection: 'mysql',
   autoCreatedAt: false,
   autoUpdatedAt: false,
   autoTK: false,
-	tableName: 'products',
+  tableName: 'products',
   attributes: {
     id: {
       type: 'integer',
@@ -97,8 +97,8 @@ module.exports = {
     },
     isDisabled: {
       type: 'boolean',
-      columnName: 'disable',
       defaultsTo: false,
+      columnName: 'disable',
     },
     hasFulfillment: {
       type: 'boolean',
@@ -131,7 +131,11 @@ module.exports = {
       type: 'integer',
       columnName: 'feature_api',
     },
-
+    deactivationInterval: {
+      type: 'string',
+      enum: ['monthly', 'yearly'],
+      defaultsTo: 'monthly',
+      columnName: 'deactivation_interval',
+    },
   },
 };
-

--- a/LegacySubmissionData.js
+++ b/LegacySubmissionData.js
@@ -1,10 +1,10 @@
 'use strict';
 
 module.exports = {
-	connection: 'mysql',
+  connection: 'mysql',
   autoCreatedAt: false,
   autoUpdatedAt: false,
-	tableName: 'submission_data',
+  tableName: 'submission_data',
   autoTK: false,
   attributes: {
     id: {
@@ -25,9 +25,9 @@ module.exports = {
     createdAt: {
       type: 'datetime',
       columnName: 'thedate',
-      defaultsTo: function() {
- return new Date();
-},
+      defaultsTo: function () {
+        return new Date();
+      },
     },
     success: {
       type: 'string',
@@ -36,7 +36,7 @@ module.exports = {
     },
     action: {
       type: 'string',
-      enum: ['submit', 'update', 'delete', 'link', 'claim', 'duplicate'],
+      enum: ['submit', 'update', 'delete', 'link', 'claim', 'duplicate', 'deactivate'],
     },
     url: {
       type: 'string',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rewind",
-  "version": "7.0.0",
+  "version": "7.0.2",
   "description": "Models Repository",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@heyharvs The field **_deactivation_interval_** was added into the **products** table as **ENUM('monthly', 'yearly')** and **monthly** was set as default value.
Also, the **LegacyProduct** model was updated with this addition.

In addition, the field **_submission_data.action_** wa updated to include "deactivate" value.

The tickets related to these changes are: 
- https://adviceinteractive.atlassian.net/browse/PLAN-261
- https://adviceinteractive.atlassian.net/browse/PLAN-263